### PR TITLE
Fix: Convert bankType from string to array for Addiko Bank

### DIFF
--- a/data/account-providers/addiko-bank.json
+++ b/data/account-providers/addiko-bank.json
@@ -3,7 +3,7 @@
   "type": [
     "account"
   ],
-  "bankType": "universal",
+  "bankType": ["universal"],
   "status": "live",
   "name": "Addiko Bank",
   "icon": "https://d1uuj3mi6rzwpm.cloudfront.net/logos/providers/at/addiko_at.svg",


### PR DESCRIPTION
- Changed bankType from "universal" to ["universal"]
- Ensures consistency with schema definition
- All other 999 banks use array format
- Fixes TypeError: bankType.map is not a function