### PR TITLE
Add Finexer as API aggregator

### DIFF
--- a/data/account-providers/adam-company.json
+++ b/data/account-providers/adam-company.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "finexer",
     "salt-edge"
   ],
   "bic": "ADAGGB2S"

--- a/data/account-providers/aib.json
+++ b/data/account-providers/aib.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "finexer",
     "plaid",
     "powens",
     "salt-edge",

--- a/data/account-providers/allied-irish-bank.json
+++ b/data/account-providers/allied-irish-bank.json
@@ -78,13 +78,14 @@
   ],
   "apiStandards": [],
   "apiAggregators": [
-    "salt-edge",
     "banqup",
-    "openwrks",
-    "friendlyscore",
-    "truelayer",
     "equensworldline",
-    "moneyhub-enterprise"
+    "finexer",
+    "friendlyscore",
+    "moneyhub-enterprise",
+    "openwrks",
+    "salt-edge",
+    "truelayer"
   ],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/americanexpress.json
+++ b/data/account-providers/americanexpress.json
@@ -87,16 +87,17 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "akahu",
     "bridgeapi-io",
     "budget-insight",
     "fidel-uk",
+    "finexer",
+    "lunchflow",
     "moneyhub-enterprise",
     "powens",
     "salt-edge",
     "tink",
-    "truelayer",
-    "akahu",
-    "lunchflow"
+    "truelayer"
   ],
   "collections": [],
   "webApplication": true,

--- a/data/account-providers/bank-of-ireland-365-online.json
+++ b/data/account-providers/bank-of-ireland-365-online.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/bank-of-ireland-business-on-line.json
+++ b/data/account-providers/bank-of-ireland-business-on-line.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/bank-of-ireland.json
+++ b/data/account-providers/bank-of-ireland.json
@@ -98,6 +98,7 @@
     "banqup",
     "bridgeapi-io",
     "equensworldline",
+    "finexer",
     "moneyhub-enterprise",
     "openwrks",
     "plaid",

--- a/data/account-providers/bank-of-scotland-business.json
+++ b/data/account-providers/bank-of-scotland-business.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "yapily"

--- a/data/account-providers/bank-of-scotland-commercial.json
+++ b/data/account-providers/bank-of-scotland-commercial.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/bank-of-scotland-gb.json
+++ b/data/account-providers/bank-of-scotland-gb.json
@@ -114,6 +114,7 @@
     "banked",
     "bridgeapi-io",
     "equensworldline",
+    "finexer",
     "fintecture",
     "friendlyscore",
     "klarna",

--- a/data/account-providers/barclaycard-commercial-payments.json
+++ b/data/account-providers/barclaycard-commercial-payments.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "salt-edge",

--- a/data/account-providers/barclaycard-uk.json
+++ b/data/account-providers/barclaycard-uk.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/barclays-business.json
+++ b/data/account-providers/barclays-business.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "yapily"

--- a/data/account-providers/barclays-corporate.json
+++ b/data/account-providers/barclays-corporate.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "yapily"

--- a/data/account-providers/barclays-wealth.json
+++ b/data/account-providers/barclays-wealth.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "volt",

--- a/data/account-providers/barclays.json
+++ b/data/account-providers/barclays.json
@@ -159,6 +159,7 @@
     "bridgeapi-io",
     "budget-insight",
     "equensworldline",
+    "finexer",
     "friendlyscore",
     "gocardless",
     "klarna",

--- a/data/account-providers/capitalontap.json
+++ b/data/account-providers/capitalontap.json
@@ -43,7 +43,9 @@
   "apiProducts": [],
   "apiStandards": [],
   "apiStatusUrls": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "finexer"
+  ],
   "collections": [],
   "webApplication": true,
   "mobileApps": [],

--- a/data/account-providers/cater-allen.json
+++ b/data/account-providers/cater-allen.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "plaid",

--- a/data/account-providers/cbs-bank.json
+++ b/data/account-providers/cbs-bank.json
@@ -31,6 +31,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "salt-edge"

--- a/data/account-providers/coutts-and-company.json
+++ b/data/account-providers/coutts-and-company.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "finexer"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/coutts-clearspend.json
+++ b/data/account-providers/coutts-clearspend.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "finexer",
     "salt-edge"
   ],
   "bic": null

--- a/data/account-providers/coutts-co.json
+++ b/data/account-providers/coutts-co.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "tink"
   ],
   "ownership": [],

--- a/data/account-providers/coutts-gb.json
+++ b/data/account-providers/coutts-gb.json
@@ -29,6 +29,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "plaid",

--- a/data/account-providers/couttsco-clearspend.json
+++ b/data/account-providers/couttsco-clearspend.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/cumberland-building-society.json
+++ b/data/account-providers/cumberland-building-society.json
@@ -29,6 +29,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "plaid",

--- a/data/account-providers/cynergy-bank.json
+++ b/data/account-providers/cynergy-bank.json
@@ -36,6 +36,7 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://openbanking.cynergybank.co.uk/store/",
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "plaid",

--- a/data/account-providers/danske-bank-business.json
+++ b/data/account-providers/danske-bank-business.json
@@ -35,6 +35,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "salt-edge",

--- a/data/account-providers/danske-bank.json
+++ b/data/account-providers/danske-bank.json
@@ -101,6 +101,7 @@
     "enablebanking",
     "enfuce",
     "equensworldline",
+    "finexer",
     "fintecture",
     "klarna",
     "neonomics",

--- a/data/account-providers/firstdirect.json
+++ b/data/account-providers/firstdirect.json
@@ -178,6 +178,7 @@
   "apiAggregators": [
     "banked",
     "equensworldline",
+    "finexer",
     "friendlyscore",
     "gocardless",
     "klarna",

--- a/data/account-providers/halifax-uk.json
+++ b/data/account-providers/halifax-uk.json
@@ -131,6 +131,7 @@
   "apiAggregators": [
     "bridgeapi-io",
     "equensworldline",
+    "finexer",
     "fintecture",
     "moneyhub-enterprise",
     "nordigen",

--- a/data/account-providers/hsbc-business.json
+++ b/data/account-providers/hsbc-business.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/hsbc-kinetic.json
+++ b/data/account-providers/hsbc-kinetic.json
@@ -39,6 +39,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "plaid",

--- a/data/account-providers/hsbc.json
+++ b/data/account-providers/hsbc.json
@@ -185,6 +185,7 @@
     "bridgeapi-io",
     "budget-insight",
     "equensworldline",
+    "finexer",
     "finverse",
     "flinks",
     "friendlyscore",

--- a/data/account-providers/hsbcnet.json
+++ b/data/account-providers/hsbcnet.json
@@ -38,6 +38,7 @@
   "stockSymbol": "",
   "apiAggregators": [
     "bridgeapi-io",
+    "finexer",
     "gocardless",
     "lunchflow",
     "plaid",

--- a/data/account-providers/jpmel.json
+++ b/data/account-providers/jpmel.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "finexer",
     "plaid",
     "salt-edge"
   ],

--- a/data/account-providers/lloyds-business.json
+++ b/data/account-providers/lloyds-business.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/lloyds-commercial.json
+++ b/data/account-providers/lloyds-commercial.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/lloyds-personal.json
+++ b/data/account-providers/lloyds-personal.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/lloyds.json
+++ b/data/account-providers/lloyds.json
@@ -165,6 +165,7 @@
     "banked",
     "bridgeapi-io",
     "equensworldline",
+    "finexer",
     "fintecture",
     "friendlyscore",
     "klarna",

--- a/data/account-providers/marks-spencer-financial-services.json
+++ b/data/account-providers/marks-spencer-financial-services.json
@@ -49,16 +49,17 @@
   "apiAuth": [],
   "apiReferenceUrl": "https://api.hsbc.com/",
   "apiAggregators": [
-    "plaid",
-    "nordigen",
-    "truelayer",
     "banked",
-    "openwrks",
-    "friendlyscore",
     "equensworldline",
+    "finexer",
+    "friendlyscore",
     "moneyhub-enterprise",
+    "nordigen",
+    "openwrks",
+    "plaid",
     "salt-edge",
-    "tink"
+    "tink",
+    "truelayer"
   ],
   "apiProducts": [],
   "apiStandards": [],

--- a/data/account-providers/mbna-uk.json
+++ b/data/account-providers/mbna-uk.json
@@ -124,14 +124,15 @@
   ],
   "apiStandards": [],
   "apiAggregators": [
-    "plaid",
-    "nordigen",
-    "fintecture",
     "bridgeapi-io",
+    "finexer",
+    "fintecture",
     "moneyhub-enterprise",
-    "truelayer",
+    "nordigen",
+    "plaid",
     "salt-edge",
-    "tink"
+    "tink",
+    "truelayer"
   ],
   "collections": [],
   "webApplication": true,

--- a/data/account-providers/mettle.json
+++ b/data/account-providers/mettle.json
@@ -66,6 +66,7 @@
     }
   ],
   "apiAggregators": [
+    "finexer",
     "friendlyscore",
     "gocardless",
     "lunchflow",

--- a/data/account-providers/mizuho-bank.json
+++ b/data/account-providers/mizuho-bank.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "finexer",
     "salt-edge"
   ],
   "bic": "MHCBJPJTXXX"

--- a/data/account-providers/monzo.json
+++ b/data/account-providers/monzo.json
@@ -72,6 +72,7 @@
   "apiStatusUrls": [],
   "apiAggregators": [
     "banked",
+    "finexer",
     "friendlyscore",
     "gocardless",
     "lunchflow",

--- a/data/account-providers/nationwide-building-society-gb.json
+++ b/data/account-providers/nationwide-building-society-gb.json
@@ -85,17 +85,18 @@
     }
   ],
   "apiAggregators": [
-    "plaid",
-    "truelayer",
-    "klarna",
-    "token",
-    "yolt",
-    "openwrks",
-    "salt-edge",
     "banked",
     "bridgeapi-io",
     "equensworldline",
-    "moneyhub-enterprise"
+    "finexer",
+    "klarna",
+    "moneyhub-enterprise",
+    "openwrks",
+    "plaid",
+    "salt-edge",
+    "token",
+    "truelayer",
+    "yolt"
   ],
   "ownership": [
     {

--- a/data/account-providers/natwest-bankline.json
+++ b/data/account-providers/natwest-bankline.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/natwest-clearspend.json
+++ b/data/account-providers/natwest-clearspend.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/natwest-international.json
+++ b/data/account-providers/natwest-international.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/natwest.json
+++ b/data/account-providers/natwest.json
@@ -91,6 +91,7 @@
     "banked",
     "bridgeapi-io",
     "equensworldline",
+    "finexer",
     "friendlyscore",
     "gocardless",
     "klarna",

--- a/data/account-providers/rbs-clearspend.json
+++ b/data/account-providers/rbs-clearspend.json
@@ -31,6 +31,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "salt-edge"

--- a/data/account-providers/rbs.json
+++ b/data/account-providers/rbs.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "finexer",
     "plaid",
     "salt-edge",
     "volt"

--- a/data/account-providers/revolut.json
+++ b/data/account-providers/revolut.json
@@ -113,6 +113,7 @@
     "bridgeapi-io",
     "budget-insight",
     "enablebanking",
+    "finexer",
     "fintecture",
     "friendlyscore",
     "gocardless",

--- a/data/account-providers/royal-bank-of-scotland-bankline.json
+++ b/data/account-providers/royal-bank-of-scotland-bankline.json
@@ -29,6 +29,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "salt-edge"

--- a/data/account-providers/royal-bank-of-scotland.json
+++ b/data/account-providers/royal-bank-of-scotland.json
@@ -67,6 +67,7 @@
     "banked",
     "bridgeapi-io",
     "equensworldline",
+    "finexer",
     "friendlyscore",
     "gocardless",
     "klarna",

--- a/data/account-providers/sainsburys-bank.json
+++ b/data/account-providers/sainsburys-bank.json
@@ -45,6 +45,7 @@
   "apiReferenceUrl": "https://developer.sainsburysbank.co.uk/api",
   "apiChangelogUrl": null,
   "apiAggregators": [
+    "finexer",
     "moneyhub-enterprise",
     "truelayer",
     "yapily"

--- a/data/account-providers/santander.json
+++ b/data/account-providers/santander.json
@@ -93,6 +93,7 @@
   ],
   "apiAggregators": [
     "bridgeapi-io",
+    "finexer",
     "gocardless",
     "klarna",
     "lunchflow",

--- a/data/account-providers/starling-bank.json
+++ b/data/account-providers/starling-bank.json
@@ -75,6 +75,7 @@
   "apiStatusUrls": [],
   "apiAggregators": [
     "banked",
+    "finexer",
     "gocardless",
     "lunchflow",
     "moneyhub-enterprise",

--- a/data/account-providers/tescobank.json
+++ b/data/account-providers/tescobank.json
@@ -87,6 +87,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "salt-edge",

--- a/data/account-providers/tide.json
+++ b/data/account-providers/tide.json
@@ -87,6 +87,7 @@
   ],
   "apiStandards": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "plaid",

--- a/data/account-providers/tsb.json
+++ b/data/account-providers/tsb.json
@@ -115,6 +115,7 @@
   "apiAggregators": [
     "akahu",
     "bridgeapi-io",
+    "finexer",
     "gocardless",
     "lunchflow",
     "nordigen",

--- a/data/account-providers/ulster-bank-bankline.json
+++ b/data/account-providers/ulster-bank-bankline.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "volt"
   ],
   "ownership": [],

--- a/data/account-providers/ulster-bank-ni.json
+++ b/data/account-providers/ulster-bank-ni.json
@@ -54,15 +54,16 @@
   ],
   "apiStandards": [],
   "apiAggregators": [
-    "truelayer",
-    "klarna",
-    "salt-edge",
-    "banqup",
     "banked",
-    "friendlyscore",
+    "banqup",
     "bridgeapi-io",
     "equensworldline",
-    "moneyhub-enterprise"
+    "finexer",
+    "friendlyscore",
+    "klarna",
+    "moneyhub-enterprise",
+    "salt-edge",
+    "truelayer"
   ],
   "webApplication": true,
   "mobileApps": [

--- a/data/account-providers/ulster-bank.json
+++ b/data/account-providers/ulster-bank.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "powens",

--- a/data/account-providers/vanquis-bank.json
+++ b/data/account-providers/vanquis-bank.json
@@ -101,6 +101,7 @@
     }
   ],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow",
     "plaid",

--- a/data/account-providers/virgin-money-sort-code-starts-with-05-or-82.json
+++ b/data/account-providers/virgin-money-sort-code-starts-with-05-or-82.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/virgin-money-sort-code-starts-with-08.json
+++ b/data/account-providers/virgin-money-sort-code-starts-with-08.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/virgin-money-uk.json
+++ b/data/account-providers/virgin-money-uk.json
@@ -103,10 +103,11 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
-    "openwrks",
+    "finexer",
     "moneyhub-enterprise",
-    "truelayer",
-    "salt-edge"
+    "openwrks",
+    "salt-edge",
+    "truelayer"
   ],
   "collections": [],
   "webApplication": true,

--- a/data/account-providers/wise-capital-limited.json
+++ b/data/account-providers/wise-capital-limited.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "finexer"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/yorkshire-bank.json
+++ b/data/account-providers/yorkshire-bank.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "finexer",
     "salt-edge",
     "yapily"
   ],

--- a/data/account-providers/yorkshire-building-society-gb.json
+++ b/data/account-providers/yorkshire-building-society-gb.json
@@ -77,6 +77,7 @@
     }
   ],
   "apiAggregators": [
+    "finexer",
     "moneyhub-enterprise",
     "plaid",
     "salt-edge",

--- a/data/account-providers/zempler-bank-formerly-cashplus.json
+++ b/data/account-providers/zempler-bank-formerly-cashplus.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "finexer",
     "yapily"
   ],
   "ownership": [],

--- a/data/api-aggregators/finexer.json
+++ b/data/api-aggregators/finexer.json
@@ -1,0 +1,20 @@
+{
+  "id": "finexer",
+  "label": "Finexer",
+  "website": "https://finexer.com",
+  "iconUrl": "https://finexer.blob.core.windows.net/logos/finexer-d128.png",
+  "developerPortalUrl": "https://finexer.com/docs",
+  "countryHQ": "GB",
+  "verified": false,
+  "marketFocus": "UK and Europe",
+  "marketCoverage": {
+    "live": [
+      "GB",
+      "IE"
+    ],
+    "upcoming": [
+      "EU"
+    ]
+  },
+  "description": "Finexer is an FCA-authorised Open Banking infrastructure provider that enables businesses to access real-time financial data and process instant payments (pay-ins & payouts)."
+}

--- a/schema.json
+++ b/schema.json
@@ -412,6 +412,7 @@
               "equensworldline",
               "fidel-uk",
               "figo",
+              "finexer",
               "finicity",
               "fintecture",
               "finverse",


### PR DESCRIPTION
## Add Finexer as API aggregator

Finexer is an open banking platform for businesses based in the United Kingdom.

### What Finexer provides:
- Data Aggregation - Access client's bank accounts in real-time across multiple financial institutions
- Instant Payments - Send money or collect payments instantly through banking infrastructure  
- Sign in via Bank - Verify customer identity online with bank information and facial recognition
- Connect - Offer financial functionality by managing accounts on user behalf

### Details:
- **Website:** https://finexer.com
- **Developer Portal:** https://finexer.com/docs
- **Country HQ:** GB (United Kingdom)
- **Market Focus:** Europe (UK-focused)

### Supported Features:
- PSD2 compliant
- FCA authorized (Payment Services Regulations 2017, reference: 925695)
- GDPR compliant
- Cyber Essentials certified

### Supported Countries:
- United Kingdom (GB)
- Ireland (IE)
- (Coverage expanding across Europe)

### Coverage:
Finexer supports major UK banks including Barclays, HSBC, Lloyds, NatWest, Nationwide, Halifax, Santander, Starling, Monzo, Revolut, and 20+ more.
