### PR TITLE
Add Sahl Financial as API aggregator

### DIFF
--- a/data/account-providers/al-akhdar-bank-ma.json
+++ b/data/account-providers/al-akhdar-bank-ma.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/al-barid-bank.json
+++ b/data/account-providers/al-barid-bank.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/arab-bank-plc-ma.json
+++ b/data/account-providers/arab-bank-plc-ma.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/attijariwafa-bank-ma.json
+++ b/data/account-providers/attijariwafa-bank-ma.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/bank-assafa-ma.json
+++ b/data/account-providers/bank-assafa-ma.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/bank-of-africa-ma.json
+++ b/data/account-providers/bank-of-africa-ma.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/banque-centrale-populaire-ma.json
+++ b/data/account-providers/banque-centrale-populaire-ma.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/banque-marocaine-pour-le-commerce-et-lindustrie-bmci-ma.json
+++ b/data/account-providers/banque-marocaine-pour-le-commerce-et-lindustrie-bmci-ma.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/cfg-bank.json
+++ b/data/account-providers/cfg-bank.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/credit-agricole-du-maroc.json
+++ b/data/account-providers/credit-agricole-du-maroc.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/credit-du-maroc.json
+++ b/data/account-providers/credit-du-maroc.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/credit-immobilier-et-hotelier.json
+++ b/data/account-providers/credit-immobilier-et-hotelier.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/societe-generale-marocaine-de-banques.json
+++ b/data/account-providers/societe-generale-marocaine-de-banques.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/umnia-bank-ma.json
+++ b/data/account-providers/umnia-bank-ma.json
@@ -22,7 +22,7 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": ["sahl"],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/api-aggregators/sahl.json
+++ b/data/api-aggregators/sahl.json
@@ -3,7 +3,7 @@
   "label": "Sahl Financial",
   "website": "https://sahlfinancial.com/",
   "iconUrl": "https://sahlfinancial.com/logo/sahl-logo-128.png",
-  "developerPortalUrl": "https://sahlfinancial.com/",
+  "developerPortalUrl": "https://sahlfinancial.com/developers",
   "countryHQ": "MA",
   "verified": false,
   "marketFocus": "Morocco",

--- a/data/api-aggregators/sahl.json
+++ b/data/api-aggregators/sahl.json
@@ -1,0 +1,14 @@
+{
+  "id": "sahl",
+  "label": "Sahl Financial",
+  "website": "https://sahlfinancial.com/",
+  "iconUrl": "https://sahlfinancial.com/logo/sahl-logo-128.png",
+  "developerPortalUrl": "https://sahlfinancial.com/",
+  "countryHQ": "MA",
+  "verified": false,
+  "marketFocus": "Morocco",
+  "marketCoverage": {
+    "live": ["MA"]
+  },
+  "description": "Open Finance infrastructure for Morocco and francophone Africa. Consent-based bank data aggregation, AI-driven alternative credit scoring, OCR/KYC, and anti-fraud APIs for banks, fintechs, and telcos. Founded in 2025 and headquartered in Casablanca."
+}

--- a/schema.json
+++ b/schema.json
@@ -433,6 +433,7 @@
               "plaid",
               "pluggy",
               "powens",
+              "sahl",
               "salt-edge",
               "six-group-b-link",
               "snaptrade",


### PR DESCRIPTION
# Add Sahl Financial as API aggregator (Morocco)

## Summary

Adds Sahl Financial as an API aggregator with live coverage in Morocco, and tags 14 Moroccan banks where Sahl has production coverage. Morocco currently shows **0 banks with API aggregator coverage** in the tracker; this PR closes that gap.

Sahl Financial is an Open Finance infrastructure company headquartered in Casablanca, founded in 2025. Website: https://sahlfinancial.com/

## What Sahl provides

- Bank data aggregation across Moroccan retail banks (consent-based)
- AI-driven alternative credit scoring
- OCR / KYC and identity verification APIs
- Anti-fraud and risk APIs

## Details

- **Website:** https://sahlfinancial.com/
- **Country HQ:** MA (Morocco)
- **Market focus:** Morocco
- **Live coverage:** MA
- **Legal entity:** SAHL FINTECH SARL, RC 662115 (Casablanca). Holding: Sahl Financial, Inc. (Delaware).
- **Customer base:** B2B — banks, fintechs, telcos, financial institutions

## Market context

Morocco is outside the EU PSD2 zone. Bank Al-Maghrib (the central bank) has not yet issued a mandatory open banking framework — Circulaire 4/W/2014 covers outsourcing and data-sharing oversight but does not mandate bank APIs. In this environment, bank data access works through **consent-based, credentials-based aggregation** with the end user's explicit authorization, similar to the pre-1033 model in the US or the Belvo / Mono model in Latin America and parts of Africa. This is reflected in the `description` field and disclosed transparently.

## Banks tagged (14)

Primary slugs only. Where the tracker has duplicate or legacy entries for the same legal entity, only the current/primary slug was tagged.

| # | Bank | File |
|---|---|---|
| 1 | Attijariwafa Bank | `attijariwafa-bank-ma` |
| 2 | Banque Centrale Populaire (BCP) | `banque-centrale-populaire-ma` |
| 3 | Bank of Africa (BMCE) | `bank-of-africa-ma` |
| 4 | Saham Bank (formerly Société Générale Maroc) | `societe-generale-marocaine-de-banques` |
| 5 | Crédit du Maroc | `credit-du-maroc` |
| 6 | BMCI | `banque-marocaine-pour-le-commerce-et-lindustrie-bmci-ma` |
| 7 | CIH | `credit-immobilier-et-hotelier` |
| 8 | Crédit Agricole du Maroc (CAM) | `credit-agricole-du-maroc` |
| 9 | CFG Bank | `cfg-bank` |
| 10 | Al Barid Bank | `al-barid-bank` |
| 11 | Bank Assafa | `bank-assafa-ma` |
| 12 | Umnia Bank | `umnia-bank-ma` |
| 13 | Al Akhdar Bank | `al-akhdar-bank-ma` |
| 14 | Arab Bank PLC (Morocco) | `arab-bank-plc-ma` |

Note on #4: Saham Group acquired Société Générale Marocaine de Banques in 2024 and has rebranded the entity as Saham Bank. The tracker still indexes it under the pre-rebrand slug, so the existing file was tagged. Happy to follow up with a separate PR to update the bank's `name` / `legalName` fields once this lands, if maintainers prefer.

## Files changed

- `data/api-aggregators/sahl.json` — new aggregator profile
- `schema.json` — added `sahl` to the `apiAggregators` enum (alphabetical position between `powens` and `salt-edge`)
- `data/account-providers/*.json` — 14 Moroccan bank files, `apiAggregators` updated from `[]` to `["sahl"]`

## Validation

- `npm run validate-aggregators` — `sahl.json` validates ✓ (5 unrelated pre-existing aggregator errors)
- `npm run validate-providers` — All data is valid ✓
- `npm run validate-links` — no new failures introduced (4 pre-existing failures on unrelated bank login URLs)

## Logo

Self-hosted at `https://sahlfinancial.com/logo/sahl-logo-128.png` (PNG, 128×128, transparent background, sourced from the official brand SVG). 512×512 PNG and SVG also available at the same path. Following the same convention as the recently merged Finexer aggregator (PR #534), which self-hosts its icon. Happy to mirror to `res.cloudinary.com/apideck/icons/sahl` if maintainers prefer — assets can be emailed to `openbankingtracker@banq.ai` on request.

## Verification

Customer references and integration evidence available on request, including a live demo of bank-data retrieval against a test account at any of the 14 banks.