### PR TITLE
Add Venn and BMO aliases

### DIFF
--- a/data/account-providers/bank-of-montreal-the-ca.json
+++ b/data/account-providers/bank-of-montreal-the-ca.json
@@ -8,10 +8,17 @@
   ],
   "name": "BANK OF MONTREAL, THE",
   "legalName": "BANK OF MONTREAL, THE",
+  "aliases": [
+    "BMO",
+    "Bank of Montreal",
+    "BMO Bank",
+    "BMO Financial Group",
+    "Banque de Montréal"
+  ],
   "verified": false,
   "status": "live",
   "icon": "https://icons.duckduckgo.com/ip3/www.bankofmontrealtheca.com.ico",
-  "websiteUrl": null,
+  "websiteUrl": "https://www.bankofmontreal.com",
   "countryHQ": "CA",
   "countries": [
     "CA"

--- a/data/account-providers/bank-of-montreal-the.json
+++ b/data/account-providers/bank-of-montreal-the.json
@@ -8,10 +8,17 @@
   ],
   "name": "BANK OF MONTREAL, THE",
   "legalName": "BANK OF MONTREAL, THE",
+  "aliases": [
+    "BMO",
+    "Bank of Montreal",
+    "BMO Bank",
+    "BMO Financial Group",
+    "Banque de Montréal"
+  ],
   "verified": false,
   "status": "live",
   "icon": "https://icons.duckduckgo.com/ip3/www.bankofmontrealthe.com.ico",
-  "websiteUrl": null,
+  "websiteUrl": "https://www.bankofmontreal.com",
   "countryHQ": "CA",
   "countries": [
     "CA"

--- a/data/account-providers/bank-of-montreal-us.json
+++ b/data/account-providers/bank-of-montreal-us.json
@@ -8,10 +8,15 @@
   ],
   "name": "BANK OF MONTREAL",
   "legalName": "BANK OF MONTREAL",
+  "aliases": [
+    "BMO",
+    "BMO Bank",
+    "BMO US"
+  ],
   "verified": false,
   "status": "live",
   "icon": "https://icons.duckduckgo.com/ip3/www.bankofmontrealus.com.ico",
-  "websiteUrl": null,
+  "websiteUrl": "https://www.bmo.com",
   "countryHQ": "US",
   "countries": [
     "US"

--- a/data/account-providers/bank-of-montreal.json
+++ b/data/account-providers/bank-of-montreal.json
@@ -8,6 +8,13 @@
   ],
   "name": "Bank OF Montreal",
   "legalName": "BANK OF MONTREAL",
+  "aliases": [
+    "BMO",
+    "BMO Bank",
+    "BMO Financial Group",
+    "Banque de Montréal",
+    "Bank of Montreal, The"
+  ],
   "verified": false,
   "status": "live",
   "icon": "https://icons.duckduckgo.com/ip3/www.bankofmontreal.com.ico",

--- a/data/account-providers/bmo-alto.json
+++ b/data/account-providers/bmo-alto.json
@@ -8,6 +8,11 @@
   ],
   "name": "BMO Alto",
   "legalName": "BMO Alto",
+  "aliases": [
+    "Bank of Montreal",
+    "BMO",
+    "BMO Bank"
+  ],
   "verified": false,
   "status": "live",
   "icon": "https://icons.duckduckgo.com/ip3/www.bmo-alto.com.ico",

--- a/data/account-providers/bmo-bank-na-us.json
+++ b/data/account-providers/bmo-bank-na-us.json
@@ -8,10 +8,15 @@
   ],
   "name": "BMO BANK N.A.",
   "legalName": "BMO BANK N.A.",
+  "aliases": [
+    "Bank of Montreal",
+    "BMO",
+    "BMO Harris"
+  ],
   "verified": false,
   "status": "live",
   "icon": "https://icons.duckduckgo.com/ip3/www.bmo-bank-na.com.ico",
-  "websiteUrl": null,
+  "websiteUrl": "https://www.bmo.com",
   "countryHQ": "US",
   "countries": [
     "US"

--- a/data/account-providers/bmo-harris-bank-na.json
+++ b/data/account-providers/bmo-harris-bank-na.json
@@ -8,10 +8,15 @@
   ],
   "name": "BMO HARRIS BANK N.A.",
   "legalName": "BMO HARRIS BANK N.A.",
+  "aliases": [
+    "Bank of Montreal",
+    "BMO",
+    "BMO Harris Bank"
+  ],
   "verified": false,
   "status": "live",
   "icon": "https://icons.duckduckgo.com/ip3/www.bmoharrisbankna.com.ico",
-  "websiteUrl": null,
+  "websiteUrl": "https://www.bmoharris.com",
   "countryHQ": "US",
   "countries": [
     "US"

--- a/data/account-providers/bmo-us.json
+++ b/data/account-providers/bmo-us.json
@@ -8,6 +8,11 @@
   ],
   "name": "BMO (US)",
   "legalName": "BMO (US)",
+  "aliases": [
+    "Bank of Montreal",
+    "BMO Bank",
+    "BMO US"
+  ],
   "verified": false,
   "status": "live",
   "icon": "https://icons.duckduckgo.com/ip3/www.bmo-us.com.ico",

--- a/data/account-providers/bmoharrisbank.json
+++ b/data/account-providers/bmoharrisbank.json
@@ -9,6 +9,12 @@
   "name": "BMO Harris Bank",
   "description": "BMO Harris Bank, N.A. is a United States bank based in Chicago, Illinois. It is a member of the Federal Reserve System and operates branches in the states of Illinois, Indiana, Arizona, Missouri, Minnesota, Kansas, Florida, Wisconsin, and California.",
   "legalName": "BMO Harris Bank, N.A.",
+  "aliases": [
+    "BMO",
+    "Bank of Montreal",
+    "BMO Bank",
+    "BMO Bank N.A."
+  ],
   "ipoStatus": "private",
   "stockSymbol": null,
   "verified": false,

--- a/data/account-providers/venn.json
+++ b/data/account-providers/venn.json
@@ -1,0 +1,150 @@
+{
+  "id": "venn",
+  "type": [
+    "account"
+  ],
+  "bankType": [
+    "challenger"
+  ],
+  "name": "Venn",
+  "legalName": "Venn Software Inc.",
+  "aliases": [
+    "Vault",
+    "Vault Payments Inc."
+  ],
+  "description": "Venn (formerly Vault) is a Canadian business banking platform for SMBs and entrepreneurs offering multi-currency accounts in CAD, USD, GBP and EUR, corporate Mastercards with cashback, expense management, accounts payable, multi-currency invoicing, FX and global wires to 180+ countries. Venn is a technology company and not a chartered bank — Venn Account Balances are held at Bank of Montreal (a CDIC member institution), and Venn Mastercard Charge Cards are issued by Peoples Trust Company. Venn Software Inc. is registered with FINTRAC as a money service business (M22941967) and is approved by the Bank of Canada as a Payment Service Provider under the Retail Payments Activities Act. Founded in 2021 in Toronto by Saud Aziz and Ahmed Shafik (former Revolut and KOHO operators) as Vault, the company rebranded to Venn in February 2025 alongside a $21.5M Series A. Venn Intelligence layers AI tools and accounting agents (auto receipt matching, AI category suggestions, rule engine) on top of the platform, and external CAD bank accounts can be linked via Plaid. Venn is currently not available to businesses in Quebec.",
+  "verified": false,
+  "status": "live",
+  "icon": "https://icons.duckduckgo.com/ip3/www.venn.ca.ico",
+  "websiteUrl": "https://www.venn.ca",
+  "alternateWebsiteUrls": [
+    "https://tryvault.com/"
+  ],
+  "countryHQ": "CA",
+  "countries": [
+    "CA"
+  ],
+  "thirdPartyBankingLicense": [
+    "bank-of-montreal"
+  ],
+  "creditCards": [
+    "mastercard"
+  ],
+  "webApplication": true,
+  "mobileApps": [],
+  "compliance": [],
+  "developerPortalUrl": null,
+  "apiStandards": [],
+  "apiProducts": [],
+  "apiAggregators": [
+    "plaid"
+  ],
+  "partnerships": [
+    {
+      "id": "bank-of-montreal",
+      "name": "Bank of Montreal",
+      "icon": "https://icons.duckduckgo.com/ip3/www.bankofmontreal.com.ico",
+      "websiteUrl": "https://www.bankofmontreal.com/",
+      "title": "Account custodian and CDIC deposit insurance",
+      "desription": "Venn Account Balances are held at Bank of Montreal, a member of the Canada Deposit Insurance Corporation (CDIC), and are eligible for CDIC deposit insurance up to applicable limits.",
+      "sourceUrl": "https://www.venn.ca/"
+    },
+    {
+      "name": "Peoples Trust Company",
+      "icon": "https://icons.duckduckgo.com/ip3/www.peoplestrust.com.ico",
+      "websiteUrl": "https://www.peoplestrust.com/",
+      "title": "Card issuer and Canadian banking rails",
+      "desription": "Venn Mastercard Charge Card is issued by Peoples Trust Company under licence from Mastercard International Incorporated. Peoples Trust also provides the underlying Canadian banking infrastructure (EFT, pre-authorized debits, CRA remittances) that powers Venn's payroll and domestic payment flows.",
+      "sourceUrl": "https://www.venn.ca/legal/cardholder-agreement"
+    },
+    {
+      "name": "Mastercard",
+      "icon": "https://icons.duckduckgo.com/ip3/www.mastercard.com.ico",
+      "websiteUrl": "https://www.mastercard.com/",
+      "title": "Card network for Venn corporate cards",
+      "desription": "Venn Mastercard Charge Card is issued under licence from Mastercard International Incorporated. Mastercard is a registered trademark, and the circles design is a trademark of Mastercard International Incorporated.",
+      "sourceUrl": "https://www.venn.ca/"
+    },
+    {
+      "name": "Interac Corp.",
+      "icon": "https://icons.duckduckgo.com/ip3/www.interac.ca.ico",
+      "websiteUrl": "https://www.interac.ca/",
+      "title": "Domestic Canadian payments network",
+      "desription": "Interac e-Transfer® is provided by Interac Corp. and used under license to power free unlimited Interac e-Transfers for Venn business accounts.",
+      "sourceUrl": "https://www.venn.ca/"
+    }
+  ],
+  "integrations": [
+    {
+      "name": "QuickBooks Online",
+      "type": "Accounting",
+      "websiteUrl": "https://quickbooks.intuit.com/"
+    },
+    {
+      "name": "Xero",
+      "type": "Accounting",
+      "websiteUrl": "https://www.xero.com/"
+    },
+    {
+      "name": "Shopify",
+      "type": "Ecommerce",
+      "websiteUrl": "https://www.shopify.com/"
+    },
+    {
+      "name": "Stripe",
+      "type": "Payments",
+      "websiteUrl": "https://stripe.com/"
+    },
+    {
+      "name": "Amazon",
+      "type": "Ecommerce",
+      "websiteUrl": "https://www.amazon.com/"
+    },
+    {
+      "name": "PayPal",
+      "type": "Payments",
+      "websiteUrl": "https://www.paypal.com/"
+    },
+    {
+      "name": "Etsy",
+      "type": "Ecommerce",
+      "websiteUrl": "https://www.etsy.com/"
+    }
+  ],
+  "ipoStatus": "private",
+  "crunchbase": "vault-7a64",
+  "ownership": [
+    {
+      "shareholderName": "Left Lane Capital",
+      "shareholderIconUrl": "https://icons.duckduckgo.com/ip3/leftlanecap.com.ico",
+      "providerId": null,
+      "sourceUrl": "https://www.venn.ca/resources/venn-series-a"
+    },
+    {
+      "shareholderName": "XYZ Venture Capital",
+      "shareholderIconUrl": "https://icons.duckduckgo.com/ip3/xyz.vc.ico",
+      "providerId": null,
+      "sourceUrl": "https://www.venn.ca/resources/venn-series-a"
+    },
+    {
+      "shareholderName": "Intact Ventures",
+      "shareholderIconUrl": "https://icons.duckduckgo.com/ip3/intactventures.com.ico",
+      "providerId": null,
+      "sourceUrl": "https://www.venn.ca/resources/venn-series-a"
+    },
+    {
+      "shareholderName": "Gradient Ventures",
+      "shareholderIconUrl": "https://icons.duckduckgo.com/ip3/gradient.com.ico",
+      "providerId": null,
+      "sourceUrl": "https://www.venn.ca/resources/venn-series-a"
+    },
+    {
+      "shareholderName": "Fin Capital",
+      "shareholderIconUrl": "https://icons.duckduckgo.com/ip3/fin.capital.ico",
+      "providerId": null,
+      "sourceUrl": "https://www.venn.ca/vault-raises-5m-in-seed-funding-round-co-led-by-gradient-ventures-and-fin-capital"
+    }
+  ],
+  "stateOwned": false,
+  "stockSymbol": null
+}

--- a/scripts/validate-links.js
+++ b/scripts/validate-links.js
@@ -28,6 +28,7 @@ const FULL_LINK_KEYS = new Set([
   ...LOGIN_KEYS,
   'icon',
   'websiteUrl',
+  'alternateWebsiteUrls',
   'developerPortalUrl',
   'developerCommunityUrl',
   'openBankProjectUrl',
@@ -204,8 +205,19 @@ function walkForLinks (node, keyName, keySet, acc, filePath, idHint) {
 
   if (Array.isArray(node)) {
     for (let i = 0; i < node.length; i++) {
+      const el = node[i]
+      // Arrays of URL strings (e.g. alternateWebsiteUrls) — parent key names the field
+      if (typeof el === 'string' && keySet.has(keyName) && /^https?:\/\//i.test(el)) {
+        acc.push({
+          url: el,
+          field: keyName,
+          file: filePath,
+          id: idHint
+        })
+        continue
+      }
       // Reset key context so nested objects expose real field names (e.g. documentationUrl in apiProducts[])
-      walkForLinks(node[i], '', keySet, acc, filePath, idHint)
+      walkForLinks(el, '', keySet, acc, filePath, idHint)
     }
     return
   }
@@ -283,7 +295,7 @@ Options:
   (default)     Scan all account-providers + third-party-providers for login URLs only
                 (${[...LOGIN_KEYS].join(', ')}).
 
-  --full        Also check other whitelisted link fields (websiteUrl, icon, docs, MCP URLs, …).
+  --full        Also check other whitelisted link fields (websiteUrl, alternateWebsiteUrls, icon, docs, MCP URLs, …).
   --aggregators Include data/api-aggregators (useful with --full).
   --no-providers Skip provider directories when using explicit paths or --aggregators-only flow.
 


### PR DESCRIPTION
## Summary
- Add **Venn** (Canadian business banking; balances custodied at Bank of Montreal) as an account provider, with `alternateWebsiteUrls` covering its prior `tryvault.com` domain.
- Add `aliases` to the 9 BMO entity records (Bank of Montreal CA/US, BMO Alto, BMO Harris, BMO Bank N.A., etc.) to improve name-based matching.
- Teach `scripts/validate-links.js --full` about arrays of URL strings (`alternateWebsiteUrls`) so they are link-checked.

## Test plan
- [ ] `npm test` (duplicate scan + JSON schema validation) passes
- [ ] `node scripts/validate-links.js --full` finds and checks the new `alternateWebsiteUrls` entry on Venn