### PR TITLE
Refresh various account-provider records

### DIFF
--- a/data/account-providers/banknovo.json
+++ b/data/account-providers/banknovo.json
@@ -5,17 +5,21 @@
   ],
   "bankType": [
     "challenger",
-    "retail"
+    "commercial"
   ],
   "name": "Novo",
-  "description": "Novo is a powerfully simple business banking platform with no hidden fees built for small business owners. Simplify your business finances with Novo.",
-  "legalName": "Novo Platform Inc",
+  "description": "Novo is an online business banking platform with no hidden fees built for small business owners. Novo is a fintech, not a bank; banking services are provided by Middlesex Federal Savings, F.A., Member FDIC, with deposits insured up to $250,000. The platform includes checking, invoicing, reserves, AI-assisted bookkeeping, integrations, funding, and small-business credit card products.",
+  "legalName": "Novo Platform Inc.",
   "ipoStatus": "private",
   "stockSymbol": null,
   "verified": false,
   "status": "live",
-  "icon": "https://play-lh.googleusercontent.com/_gQ3FOAD7Cx65Mn9R_F7QxqioHUGXcKEBP1Qwq-wsugPFWHfmBFB5Ell7-XDD3IZOdY=w480-h960-rw",
-  "websiteUrl": "https://novo.co/",
+  "icon": "https://img.logo.dev/novo.co?token=pk_GiSqTFfUTg-XEl0b5pMqWA",
+  "websiteUrl": "https://www.novo.co/",
+  "alternateWebsiteUrls": [
+    "https://novo.co/"
+  ],
+  "commercialWebLoginUrl": "https://app.novo.co/login",
   "ownership": [],
   "stateOwned": false,
   "countryHQ": "US",
@@ -42,11 +46,11 @@
   "mobileApps": [
     {
       "operatingSystem": "ios",
-      "storeUrl": "https://itunes.apple.com/us/app/novo-startup-banking/id1375554760?mt=8"
+      "storeUrl": "https://apps.apple.com/us/app/novo-small-business-checking/id1375554760"
     },
     {
       "operatingSystem": "android",
-      "storeUrl": "https://play.google.com/store/apps/details?id=com.novo.android&utm_source=marketing-website&utm_campaign=organic&pcampaignid=pcampaignidmkt-other-global-all-co-prtnr-py-partbadge-mar2515-1"
+      "storeUrl": "https://play.google.com/store/apps/details?id=com.novo.android"
     }
   ],
   "financialReports": [],
@@ -66,7 +70,7 @@
   ],
   "thirdPartyBankingLicense": "middlesexfederal",
   "debitCardLicense": null,
-  "creditCardLicense": null,
+  "creditCardLicense": "continental-bank",
   "debitAccountLicense": null,
   "strategies": [],
   "prepaidCards": [],
@@ -74,7 +78,9 @@
   "debitCards": [
     "mastercard"
   ],
-  "creditCards": [],
+  "creditCards": [
+    "mastercard"
+  ],
   "virtualCards": [],
   "applePay": false,
   "googlePay": false,
@@ -127,7 +133,17 @@
       "id": "middlesexfederal",
       "name": "Middlesex Federal Savings",
       "icon": "https://res.cloudinary.com/apideck/image/upload/v1602115143/icons/middlesexfederal.jpg",
-      "websiteUrl": "https://www.middlesexfederal.com/"
+      "websiteUrl": "https://www.middlesexfederal.com/",
+      "desription": "Banking services and the Novo Debit Card are provided by Middlesex Federal Savings, F.A., Member FDIC.",
+      "sourceUrl": "https://www.novo.co/"
+    },
+    {
+      "id": "continental-bank",
+      "name": "Continental Bank",
+      "icon": "https://icons.duckduckgo.com/ip3/www.cbankus.com.ico",
+      "websiteUrl": "https://www.cbankus.com/",
+      "desription": "The Novo Business Credit Card is issued by Continental Bank, pursuant to licenses from Mastercard International Incorporated.",
+      "sourceUrl": "https://www.novo.co/"
     }
   ],
   "rewardPartners": [

--- a/data/account-providers/belfius.json
+++ b/data/account-providers/belfius.json
@@ -15,6 +15,8 @@
   "status": "live",
   "icon": "https://res.cloudinary.com/banq/image/upload/v1552296072/radar/icons/Belfius.jpg",
   "websiteUrl": "https://www.belfius.be/about-us/en/who-we-are",
+  "retailWebLoginUrl": "https://www.belfius.be/retail/nl/loginapp/index.aspx",
+  "commercialWebLoginUrl": "https://belfiusweb.belfius.be/publiccorporate/en/my-belfiusweb/index.aspx",
   "ownership": [
     {
       "shareholderName": "Belgian State",

--- a/data/account-providers/found.json
+++ b/data/account-providers/found.json
@@ -4,10 +4,12 @@
     "account"
   ],
   "bankType": [
-    "retail"
+    "challenger",
+    "commercial"
   ],
   "name": "Found",
-  "legalName": "Found",
+  "legalName": "Indie Technologies, Inc.",
+  "description": "Found is an all-in-one financial platform for self-employed and small-business owners, combining business banking, bookkeeping, invoicing, and tax tools. Found is a financial technology company, not a bank; banking services and the Found Mastercard Business debit card are provided by Lead Bank, Member FDIC, with deposits eligible for FDIC insurance up to applicable limits. Some customers may have accounts governed by separate terms with Piermont Bank, Member FDIC, as disclosed in Found’s legal agreements.",
   "verified": false,
   "status": "live",
   "icon": "https://icons.duckduckgo.com/ip3/www.found.com.ico",
@@ -16,14 +18,39 @@
   "countries": [
     "US"
   ],
+  "thirdPartyBankingLicense": "lead-bank-business",
   "webApplication": true,
-  "mobileApps": [],
+  "mobileApps": [
+    {
+      "operatingSystem": "ios"
+    },
+    {
+      "operatingSystem": "android"
+    }
+  ],
   "compliance": [],
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
     "plaid"
+  ],
+  "partnerships": [
+    {
+      "id": "lead-bank-business",
+      "name": "Lead Bank",
+      "icon": "https://icons.duckduckgo.com/ip3/lead.bank.ico",
+      "websiteUrl": "https://www.lead.bank/",
+      "desription": "Found is a financial technology company, not a bank. Banking services are provided by Lead Bank, Member FDIC.",
+      "sourceUrl": "https://found.com/help/getting-started/is-found-fdic-insured"
+    },
+    {
+      "name": "Plaid",
+      "icon": "https://icons.duckduckgo.com/ip3/plaid.com.ico",
+      "websiteUrl": "https://plaid.com/",
+      "desription": "Found partners with Plaid to link external bank accounts to your Found account for transfers.",
+      "sourceUrl": "https://found.com/help/funding-your-found-account/how-do-i-link-a-bank-account-to-found"
+    }
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/meow.json
+++ b/data/account-providers/meow.json
@@ -4,27 +4,139 @@
     "account"
   ],
   "bankType": [
-    "retail"
+    "challenger"
   ],
   "name": "Meow",
-  "legalName": "Meow",
+  "legalName": "Meow Technologies, Inc.",
+  "description": "Meow Technologies is a financial technology company offering business banking, corporate cards, global treasury (U.S. T-Bills, U.K. Gilts, German Bunds via BNY Pershing), international payouts in 50+ currencies, invoicing, and stablecoin (USDC/USDT) services. It serves businesses, VC firms, real estate funds, and startups globally, with banking services provided by Cross River Bank and Grasshopper Bank, N.A. (both FDIC members). In April 2026, Meow launched the world's first agentic banking platform, enabling AI agents to open and manage business bank accounts via CLI and MCP server.",
   "verified": false,
   "status": "live",
   "icon": "https://icons.duckduckgo.com/ip3/www.meow.com.ico",
-  "websiteUrl": "https://meow.com",
+  "websiteUrl": "https://www.meow.com",
   "countryHQ": "US",
   "countries": [
     "US"
   ],
+  "thirdPartyBankingLicense": [
+    "cross-river-bank",
+    "grasshopper"
+  ],
   "webApplication": true,
   "mobileApps": [],
   "compliance": [],
-  "developerPortalUrl": null,
+  "developerPortalUrl": "https://www.meow.com/llms.txt",
+  "mcpServer": {
+    "type": "hosted",
+    "transport": "sse",
+    "serverUrl": "https://mcp.meow.com/",
+    "npmPackage": "@joinmeow/cli",
+    "command": "meow",
+    "args": [
+      "mcp"
+    ],
+    "authType": "api_key",
+    "documentationUrl": "https://www.meow.com/skills.md",
+    "programStatus": "live",
+    "accessLevel": "read-write",
+    "tools": [
+      "start-onboarding",
+      "create-account",
+      "verify-email",
+      "pay",
+      "card",
+      "invoice",
+      "upload",
+      "confirm"
+    ],
+    "capabilities": [
+      "account-data",
+      "payments",
+      "cards",
+      "invoicing",
+      "onboarding"
+    ],
+    "supportedModels": [
+      "Claude",
+      "ChatGPT",
+      "Cursor",
+      "Gemini"
+    ]
+  },
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
     "plaid"
   ],
+  "partnerships": [
+    {
+      "id": "cross-river-bank",
+      "name": "Cross River Bank",
+      "icon": "https://icons.duckduckgo.com/ip3/www.crossriver.com.ico",
+      "websiteUrl": "https://www.crossriver.com/",
+      "title": "Banking services and FDIC deposit insurance",
+      "desription": "Banking services are provided by Cross River Bank, Member FDIC. The FDIC's deposit insurance coverage only protects against the failure of an FDIC-insured bank.",
+      "sourceUrl": "https://www.meow.com/"
+    },
+    {
+      "id": "grasshopper",
+      "name": "Grasshopper Bank, N.A.",
+      "icon": "https://icons.duckduckgo.com/ip3/www.grasshopper.bank.ico",
+      "websiteUrl": "https://www.grasshopper.bank/",
+      "title": "Banking services and FDIC deposit insurance",
+      "desription": "Banking services are provided by Grasshopper Bank, N.A., Member FDIC. Deposit placement through IntraFi Cash Service is available for extended FDIC insurance coverage up to $200 million.",
+      "sourceUrl": "https://www.meow.com/"
+    },
+    {
+      "name": "Community Federal Savings Bank",
+      "icon": "https://icons.duckduckgo.com/ip3/www.communityfederalsavingsbank.com.ico",
+      "websiteUrl": "https://www.communityfederalsavingsbank.com/",
+      "title": "Meow Commercial Card issuer",
+      "desription": "The Meow Commercial Card is issued by Community Federal Savings Bank, pursuant to a license from VISA U.S.A. Inc.",
+      "sourceUrl": "https://www.meow.com/for-businesses"
+    },
+    {
+      "name": "Airwallex US, LLC",
+      "icon": "https://icons.duckduckgo.com/ip3/www.airwallex.com.ico",
+      "websiteUrl": "https://www.airwallex.com/",
+      "title": "Payment services",
+      "desription": "Payment services are provided through Airwallex US, LLC (NMLS #1928093).",
+      "sourceUrl": "https://www.meow.com/for-businesses"
+    },
+    {
+      "name": "Bridge Ventures LLC",
+      "icon": "https://icons.duckduckgo.com/ip3/www.bridge.xyz.ico",
+      "websiteUrl": "https://www.bridge.xyz/",
+      "title": "Stablecoin payment services",
+      "desription": "The payment services described are provided by Bridge Ventures LLC and its affiliates, registered and licensed where applicable.",
+      "sourceUrl": "https://www.meow.com/"
+    },
+    {
+      "name": "Atomic Invest LLC",
+      "icon": "https://icons.duckduckgo.com/ip3/atomicvest.com.ico",
+      "websiteUrl": "https://atomicvest.com/",
+      "title": "Investment advisory (subadvisory services)",
+      "desription": "Meow Advisory LLC has an engagement with Atomic Invest LLC, an SEC-registered investment adviser, for investment advisory account services. Brokerage services for Atomic Invest are provided by Pershing Advisor Solutions LLC (PAS), Member FINRA/SIPC.",
+      "sourceUrl": "https://www.meow.com/"
+    },
+    {
+      "name": "Atomic Brokerage LLC",
+      "icon": "https://icons.duckduckgo.com/ip3/atomicvest.com.ico",
+      "websiteUrl": "https://atomicvest.com/",
+      "title": "Brokerage services",
+      "desription": "Meow Advisory LLC has an engagement with Atomic Brokerage LLC, a registered broker-dealer and member of FINRA and SIPC, to provide brokerage account services. Custodial and clearing services are provided by BNY Pershing.",
+      "sourceUrl": "https://www.meow.com/treasury"
+    },
+    {
+      "name": "IntraFi Network LLC",
+      "icon": "https://icons.duckduckgo.com/ip3/www.intrafi.com.ico",
+      "websiteUrl": "https://www.intrafi.com/",
+      "title": "Extended FDIC deposit insurance via sweep network",
+      "desription": "Deposits may be placed through IntraFi Cash Service at FDIC-insured banks in IntraFi's network for up to $200 million in FDIC insurance coverage. Deposit placement is subject to IntraFi terms and conditions.",
+      "sourceUrl": "https://www.meow.com/"
+    }
+  ],
+  "ipoStatus": "private",
+  "crunchbase": "meow-technologies",
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null

--- a/data/account-providers/mercury.json
+++ b/data/account-providers/mercury.json
@@ -16,7 +16,7 @@
   "countries": [
     "US"
   ],
-  "description": "Mercury is a financial technology company that partners with FDIC insured partner banks to protect your money. Mercury offers its users a “banking stack”, with the goal of empowering startups, as well as making banking easier for all businesses.",
+  "description": "Mercury is a financial technology company that partners with FDIC insured partner banks to protect your money. Mercury offers its users a “banking stack”, with the goal of empowering startups, as well as making banking easier for all businesses. In April 2026, Mercury acquired Central (YC S24), an AI-native payroll, benefits, and compliance platform for startups, to add payroll to its product suite.",
   "webApplication": true,
   "mobileApps": [],
   "compliance": [],
@@ -35,7 +35,7 @@
     },
     {
       "label": "Transactions",
-      "type": "transactions",
+      "type": "accountInformation",
       "categories": ["accounts"],
       "description": "Download and search your full transaction history",
       "documentationUrl": "https://docs.mercury.com/reference",
@@ -76,6 +76,16 @@
   ],
   "apiAggregators": [
     "plaid"
+  ],
+  "articles": [
+    {
+      "url": "https://mercury.com/blog/mercury-acquires-centralhq",
+      "date": "2026-04-02"
+    },
+    {
+      "url": "https://www.linkedin.com/posts/rywiggs_excited-to-announce-mercury-has-acquired-activity-7445503331625758721-Eu68",
+      "date": "2026-04-02"
+    }
   ],
   "ownership": [],
   "stateOwned": false,

--- a/data/account-providers/monument-bank-limited-gb.json
+++ b/data/account-providers/monument-bank-limited-gb.json
@@ -8,21 +8,46 @@
   ],
   "name": "MONUMENT BANK LIMITED",
   "legalName": "MONUMENT BANK LIMITED",
+  "description": "Monument (Monument Bank Ltd.)\n\nMonument is a Financial Services company. Monument Bank offers savings accounts and handpicked lifestyle services to help individuals prosper. Monument employs 98 people (+12.9% YoY, +15 people) and has an annual revenue of $4.1M.",
   "verified": false,
   "status": "live",
   "icon": "https://icons.duckduckgo.com/ip3/www.monument-bank-limited.com.ico",
-  "websiteUrl": null,
+  "websiteUrl": "https://www.monument.co",
   "countryHQ": "GB",
   "countries": [
     "GB"
   ],
   "webApplication": true,
-  "mobileApps": [],
+  "mobileApps": [
+    {
+      "operatingSystem": "ios"
+    },
+    {
+      "operatingSystem": "android"
+    }
+  ],
   "compliance": [],
   "developerPortalUrl": null,
+  "mcpServer": {
+    "type": "hosted",
+    "transport": "sse",
+    "programStatus": "beta",
+    "accessLevel": "read-only"
+  },
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "belvo",
+    "finicity",
+    "gocardless",
+    "mx",
+    "plaid",
+    "salt-edge",
+    "tink",
+    "truelayer",
+    "yapily",
+    "yodlee"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/permanent-tsb.json
+++ b/data/account-providers/permanent-tsb.json
@@ -8,12 +8,16 @@
   ],
   "name": "Permanent TSB",
   "legalName": "Permanent TSB PLC",
+  "description": "Permanent TSB is an Irish retail bank offering personal and business banking, mortgages, savings, and cards in Ireland. It publishes a developer portal for PSD2 open banking, including account information, payment initiation, and confirmation of funds. The group is listed in London (ticker IL0A); the Irish state holds a majority stake via the Department of Finance.",
   "ipoStatus": "public",
   "stockSymbol": "LON: IL0A",
   "verified": false,
   "status": "live",
   "icon": "https://res.cloudinary.com/apideck/image/upload/v1568782021/radar/icons/permanent-tsb.jpg",
   "websiteUrl": "https://www.permanenttsb.ie/",
+  "alternateWebsiteUrls": [
+    "https://www.ptsb.ie/"
+  ],
   "ownership": [
     {
       "shareholderName": "Department of Finance Ireland",

--- a/data/account-providers/slash.json
+++ b/data/account-providers/slash.json
@@ -12,7 +12,7 @@
   "description": "Slash is an all-in-one business banking and finance platform for entrepreneurs and growing companies. The platform combines business checking, corporate cards (Slash Platinum Visa), expense management, treasury, working capital, and multi-rail payments including stablecoins. Slash offers AI-powered automation through agents and a hosted MCP server for developer integrations. Founded in San Francisco, the company serves US-based businesses with a focus on simplifying financial operations across accounting, payments, and cash management.",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ipCjec3/www.slash.com.ico",
+  "icon": "https://icons.duckduckgo.com/ip3/www.slash.com.ico",
   "websiteUrl": "https://www.slash.com",
   "countryHQ": "US",
   "countries": [


### PR DESCRIPTION
## Summary
Independent record refreshes across eight account providers:

- **Novo** — corrected fintech disclosure (Middlesex Federal as bank of record), added Continental Bank credit-card partnership, web/mobile/login URL cleanup, Mastercard credit card.
- **Belfius** — added retail (\`retailWebLoginUrl\`) and commercial (\`commercialWebLoginUrl\`) web login URLs.
- **Found** — legal name (Indie Technologies, Inc.), Lead Bank partnership, bank-type and platform description.
- **Meow** — agentic-banking refresh: challenger reclassification, Cross River + Grasshopper partnerships, hosted MCP server metadata, expanded description.
- **Mercury** — noted CentralHQ payroll acquisition (Apr 2026), fixed \`apiProducts.type\` for Transactions (\`transactions\` → \`accountInformation\`), added two source articles.
- **Monument Bank (GB)** — record refresh.
- **Permanent TSB** — added description and \`alternateWebsiteUrls\` (\`ptsb.ie\`).
- **Slash** — fixed mangled icon URL.

## Test plan
- [ ] \`npm test\` (duplicate scan + JSON schema validation) passes
- [ ] Spot-check provider pages render correctly downstream