### PR TITLE
feat(mercury): add MCP server metadata

### DIFF
--- a/data/account-providers/mercury.json
+++ b/data/account-providers/mercury.json
@@ -21,6 +21,28 @@
   "mobileApps": [],
   "compliance": [],
   "developerPortalUrl": "https://docs.mercury.com/reference",
+  "mcpServer": {
+    "type": "hosted",
+    "transport": "sse",
+    "serverUrl": "https://mcp.mercury.com/mcp",
+    "authType": "oauth",
+    "documentationUrl": "https://docs.mercury.com/docs/what-is-mercury-mcp",
+    "programStatus": "beta",
+    "accessLevel": "read-only",
+    "launchDate": "2025-11-27",
+    "capabilities": [
+      "account-data",
+      "transaction-analysis",
+      "card-data",
+      "recipient-data",
+      "statements"
+    ],
+    "supportedModels": [
+      "Claude",
+      "ChatGPT",
+      "Google AI Studio"
+    ]
+  },
   "apiStandards": [],
   "apiProducts": [
     {


### PR DESCRIPTION
## Summary

Adds an `mcpServer` block to `mercury.json` describing Mercury's hosted MCP server, launched 2025-11-27 at `mcp.mercury.com/mcp`.

This populates Mercury into the `mcpProviders` index that powers `/agentic-banking-and-mcp` and the new `/banks-with-mcp-servers` directory page in the app repo (separate PR).

## Details

| Field | Value |
|-------|-------|
| Type | hosted |
| Transport | SSE |
| Server URL | `https://mcp.mercury.com/mcp` |
| Auth | OAuth one-click |
| Status | beta |
| Access level | read-only |
| Launch date | 2025-11-27 |
| Capabilities | account-data, transaction-analysis, card-data, recipient-data, statements |
| Supported clients | Claude, ChatGPT, Google AI Studio |

Source: https://docs.mercury.com/docs/what-is-mercury-mcp

## Test plan

- [ ] Confirm `mcpProviders.json` regenerates correctly when `scripts/generateProviderIndex.mjs` runs in the app repo
- [ ] Confirm Mercury appears on `/agentic-banking-and-mcp` and `/banks-with-mcp-servers` after the app PR merges

Made with [Cursor](https://cursor.com)