### PR TITLE
Add GoDutch as Dutch business banking provider

### DIFF
--- a/data/account-providers/godutch.json
+++ b/data/account-providers/godutch.json
@@ -1,0 +1,28 @@
+{
+  "id": "godutch",
+  "type": [
+    "account"
+  ],
+  "bankType": [
+    "challenger"
+  ],
+  "name": "GoDutch",
+  "verified": false,
+  "status": "live",
+  "icon": "https://icons.duckduckgo.com/ip3/godutch.com.ico",
+  "websiteUrl": "https://godutch.com/",
+  "countryHQ": "NL",
+  "countries": [
+    "NL"
+  ],
+  "description": "GoDutch is a Netherlands-based business banking fintech offering digital business accounts with Dutch IBANs, Mastercard/Visa debit cards (physical and virtual), expense management, international payments to 160+ countries in 20+ currencies, automated bill payments, and accounting software integrations. It serves freelancers, BVs, startups, associations, VVEs, and holdings, with 20,000+ customers.",
+  "webApplication": true,
+  "mobileApps": [],
+  "compliance": [],
+  "apiStandards": [],
+  "apiProducts": [],
+  "apiAggregators": [],
+  "ownership": [],
+  "stateOwned": false,
+  "stockSymbol": null
+}


### PR DESCRIPTION
## Summary
- Adds `data/account-providers/godutch.json` for [GoDutch](https://godutch.com/), a Netherlands-based business banking fintech (20,000+ customers; freelancers, BVs, startups, associations, VVEs, holdings).
- No public API / developer portal advertised, so `apiProducts` and `apiAggregators` are empty.

## Test plan
- [x] JSON validates / duplicate-check pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)