### PR TITLE
feat: add QuickBooks as a bank-data aggregator

### DIFF
--- a/data/api-aggregators/quickbooks.json
+++ b/data/api-aggregators/quickbooks.json
@@ -1,0 +1,19 @@
+{
+  "id": "quickbooks",
+  "label": "QuickBooks",
+  "iconUrl": "https://icons.duckduckgo.com/ip3/quickbooks.intuit.com.ico",
+  "website": "https://quickbooks.intuit.com/",
+  "developerPortalUrl": "https://developer.intuit.com/app/developer/qbo/docs/get-started",
+  "statusUrl": "https://status.developer.intuit.com/",
+  "twitter": "QuickBooks",
+  "countryHQ": "US",
+  "marketCoverage": {
+    "live": [
+      "US",
+      "CA",
+      "GB",
+      "AU"
+    ]
+  },
+  "sourceUrl": "https://digitalasset.intuit.com/DOCUMENT/A0e3F3s2b/SupportedBanksList_QBO_US_EXT_020421.pdf"
+}


### PR DESCRIPTION
## Summary
- Add `data/api-aggregators/quickbooks.json` so QuickBooks shows up alongside Plaid, Finicity, Yodlee, and the other bank-data aggregators that small businesses use through their accounting systems.
- QuickBooks Online connects directly to ~2,900 U.S. banks, credit unions, and credit-card issuers (per Intuit's official supported-banks list) — by far the largest accounting-system bank-feed footprint in the U.S.

## Why
Open Banking Tracker already covers PSD2 / open-banking aggregators thoroughly, but the accounting-system tier (QuickBooks, Xero, Sage, FreeAgent) is where most U.S. SMBs actually consume bank data. Adding QuickBooks closes that gap and lets the app surface a "Banks That Support QuickBooks" directory page powered from the standard data shape.

## Source
Intuit Supported Banks List (QBO US, dated 2021-01-26):
https://digitalasset.intuit.com/DOCUMENT/A0e3F3s2b/SupportedBanksList_QBO_US_EXT_020421.pdf

## Validation
- \`node scripts/validate-file.js data/api-aggregators/quickbooks.json\` → ✅ VALID
- No duplicate-id collisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)