### PR TITLE
Add Fena as API aggregator

### DIFF
--- a/data/account-providers/aib-bank.json
+++ b/data/account-providers/aib-bank.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+      "fena",
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/aib-gb-business.json
+++ b/data/account-providers/aib-gb-business.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "fena",
     "volt"
   ],
   "ownership": [],

--- a/data/account-providers/aib-ni-business.json
+++ b/data/account-providers/aib-ni-business.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "fena",
     "volt"
   ],
   "ownership": [],

--- a/data/account-providers/aib.json
+++ b/data/account-providers/aib.json
@@ -31,6 +31,7 @@
   "stockSymbol": "",
   "apiAggregators": [
     "finexer",
+    "fena",
     "plaid",
     "powens",
     "salt-edge",

--- a/data/account-providers/bank-of-ireland-365-online.json
+++ b/data/account-providers/bank-of-ireland-365-online.json
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "finexer",
+    "fena",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/bank-of-ireland.json
+++ b/data/account-providers/bank-of-ireland.json
@@ -99,6 +99,7 @@
     "bridgeapi-io",
     "equensworldline",
     "finexer",
+    "fena",
     "moneyhub-enterprise",
     "openwrks",
     "plaid",

--- a/data/account-providers/bank-of-scotland-business.json
+++ b/data/account-providers/bank-of-scotland-business.json
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "finexer",
+    "fena",
     "gocardless",
     "lunchflow",
     "yapily"

--- a/data/account-providers/bank-of-scotland-commercial.json
+++ b/data/account-providers/bank-of-scotland-commercial.json
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "finexer",
+    "fena",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/bank-of-scotland-personal.json
+++ b/data/account-providers/bank-of-scotland-personal.json
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
+    "fena",
     "lunchflow",
     "yapily"
   ],

--- a/data/account-providers/barclays-business.json
+++ b/data/account-providers/barclays-business.json
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "finexer",
+    "fena",
     "gocardless",
     "lunchflow",
     "yapily"

--- a/data/account-providers/barclays-corporate.json
+++ b/data/account-providers/barclays-corporate.json
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "finexer",
+    "fena",
     "gocardless",
     "lunchflow",
     "yapily"

--- a/data/account-providers/barclays-personal.json
+++ b/data/account-providers/barclays-personal.json
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "gocardless",
+    "fena",
     "lunchflow",
     "yapily"
   ],

--- a/data/account-providers/chase.json
+++ b/data/account-providers/chase.json
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "flinks",
+    "fena",
     "gocardless",
     "lunchflow",
     "plaid",

--- a/data/account-providers/coutts-gb.json
+++ b/data/account-providers/coutts-gb.json
@@ -30,6 +30,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "finexer",
+    "fena",
     "gocardless",
     "lunchflow",
     "plaid",

--- a/data/account-providers/danske-bank-business.json
+++ b/data/account-providers/danske-bank-business.json
@@ -36,6 +36,7 @@
   "stockSymbol": "",
   "apiAggregators": [
     "finexer",
+    "fena",
     "gocardless",
     "lunchflow",
     "salt-edge",

--- a/data/account-providers/danske-bank.json
+++ b/data/account-providers/danske-bank.json
@@ -103,6 +103,7 @@
     "equensworldline",
     "finexer",
     "fintecture",
+    "fena",
     "klarna",
     "neonomics",
     "openwrks",

--- a/data/account-providers/firstdirect.json
+++ b/data/account-providers/firstdirect.json
@@ -179,6 +179,7 @@
     "banked",
     "equensworldline",
     "finexer",
+    "fena",
     "friendlyscore",
     "gocardless",
     "klarna",

--- a/data/account-providers/halifax-personal.json
+++ b/data/account-providers/halifax-personal.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "fena",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/hsbc-business.json
+++ b/data/account-providers/hsbc-business.json
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "finexer",
+    "fena",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/hsbc-personal.json
+++ b/data/account-providers/hsbc-personal.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "fena",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/hsbcnet.json
+++ b/data/account-providers/hsbcnet.json
@@ -39,6 +39,7 @@
   "apiAggregators": [
     "bridgeapi-io",
     "finexer",
+    "fena",
     "gocardless",
     "lunchflow",
     "plaid",

--- a/data/account-providers/lloyds-business.json
+++ b/data/account-providers/lloyds-business.json
@@ -24,6 +24,7 @@
   "apiProducts": [],
   "apiAggregators": [
     "finexer",
+    "fena",
     "gocardless",
     "lunchflow"
   ],

--- a/data/account-providers/lloyds-personal.json
+++ b/data/account-providers/lloyds-personal.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "fena",
     "finexer",
     "gocardless",
     "lunchflow"

--- a/data/account-providers/mettle.json
+++ b/data/account-providers/mettle.json
@@ -66,6 +66,7 @@
     }
   ],
   "apiAggregators": [
+    "fena",
     "finexer",
     "friendlyscore",
     "gocardless",

--- a/data/account-providers/monzo.json
+++ b/data/account-providers/monzo.json
@@ -72,6 +72,7 @@
   "apiStatusUrls": [],
   "apiAggregators": [
     "banked",
+    "fena",
     "finexer",
     "friendlyscore",
     "gocardless",

--- a/data/account-providers/nationwide.json
+++ b/data/account-providers/nationwide.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "fena",
     "gocardless",
     "lunchflow",
     "tink",

--- a/data/account-providers/natwest.json
+++ b/data/account-providers/natwest.json
@@ -91,6 +91,7 @@
     "banked",
     "bridgeapi-io",
     "equensworldline",
+    "fena",
     "finexer",
     "friendlyscore",
     "gocardless",

--- a/data/account-providers/rbs.json
+++ b/data/account-providers/rbs.json
@@ -30,6 +30,7 @@
   "stateOwned": false,
   "stockSymbol": "",
   "apiAggregators": [
+    "fena",
     "finexer",
     "plaid",
     "salt-edge",

--- a/data/account-providers/revolut.json
+++ b/data/account-providers/revolut.json
@@ -113,6 +113,7 @@
     "bridgeapi-io",
     "budget-insight",
     "enablebanking",
+    "fena",
     "finexer",
     "fintecture",
     "friendlyscore",

--- a/data/account-providers/santander.json
+++ b/data/account-providers/santander.json
@@ -93,6 +93,7 @@
   ],
   "apiAggregators": [
     "bridgeapi-io",
+    "fena",
     "finexer",
     "gocardless",
     "klarna",

--- a/data/account-providers/starling-bank.json
+++ b/data/account-providers/starling-bank.json
@@ -75,6 +75,7 @@
   "apiStatusUrls": [],
   "apiAggregators": [
     "banked",
+    "fena",
     "finexer",
     "gocardless",
     "lunchflow",

--- a/data/account-providers/tide.json
+++ b/data/account-providers/tide.json
@@ -87,6 +87,7 @@
   ],
   "apiStandards": [],
   "apiAggregators": [
+    "fena",
     "finexer",
     "gocardless",
     "lunchflow",

--- a/data/account-providers/tsb.json
+++ b/data/account-providers/tsb.json
@@ -115,6 +115,7 @@
   "apiAggregators": [
     "akahu",
     "bridgeapi-io",
+    "fena",
     "finexer",
     "gocardless",
     "lunchflow",

--- a/data/account-providers/ulster-bank.json
+++ b/data/account-providers/ulster-bank.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "fena",
     "finexer",
     "gocardless",
     "lunchflow",

--- a/data/account-providers/virgin-money-uk.json
+++ b/data/account-providers/virgin-money-uk.json
@@ -103,6 +103,7 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
+    "fena",
     "finexer",
     "moneyhub-enterprise",
     "openwrks",

--- a/data/account-providers/zempler.json
+++ b/data/account-providers/zempler.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "fena",
     "gocardless",
     "lunchflow",
     "tink"

--- a/data/api-aggregators/fena.json
+++ b/data/api-aggregators/fena.json
@@ -1,0 +1,21 @@
+{
+    "id": "fena",
+    "label": "Fena",
+    "website": "https://fena.co/",
+    "iconUrl": "https://storage.googleapis.com/fena-prod/fena_logo2.jpg",
+    "developerPortalUrl": "https://toolkit-docs.fena.co/",
+    "twitter": "fenapayment",
+    "countryHQ": "GB",
+    "verified": false,
+    "marketFocus": "United Kingdom",
+    "marketCoverage": {
+        "live": [
+            "GB"
+        ],
+        "upcoming": []
+    },
+    "bankCount": 41,
+    "connectorCount": 41,
+    "description": "Open banking payments and API infrastructure platform for merchants, partners, and fintech integrations, including account-to-account payment plugins for platforms like Shopify and WooCommerce.",
+    "note": "Open banking payments and API infrastructure platform for merchants, partners, and fintech integrations, including account-to-account payment plugins for platforms like Shopify and WooCommerce."
+}

--- a/schema.json
+++ b/schema.json
@@ -411,6 +411,7 @@
               "enablebanking",
               "enfuce",
               "equensworldline",
+              "fena",
               "fidel-uk",
               "figo",
               "finexer",


### PR DESCRIPTION
Adds Fena as an API aggregator provider.

Included:
- aggregator profile
- supported bank mappings