### PR TITLE
fix(aib-bank): remove trailing comma making JSON invalid

### DIFF
--- a/data/account-providers/aib-bank.json
+++ b/data/account-providers/aib-bank.json
@@ -23,7 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
-      "fena",
+    "fena"
   ],
   "ownership": [],
   "stateOwned": false,


### PR DESCRIPTION
## Summary
`data/account-providers/aib-bank.json` had a trailing comma after `"fena"` (introduced in #554), making the file invalid JSON. Consumer-app generators skipped the file with a warning on every run, so AIB Bank was missing from the Fena aggregator's provider count.

```diff
   "apiAggregators": [
-      "fena",
+    "fena"
   ],
```

Caught while wiring up automatic snapshot regeneration in the consumer app (open-banking-tracker-app #142). Scanned the rest of `data/account-providers/` — no other parse errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)