### PR TITLE
feat(account-providers): add XONO

### DIFF
--- a/data/account-providers/xono.json
+++ b/data/account-providers/xono.json
@@ -1,0 +1,36 @@
+{
+  "id": "xono",
+  "type": [
+    "account",
+    "crypto"
+  ],
+  "bankType": [
+    "challenger",
+    "commercial"
+  ],
+  "name": "XONO",
+  "legalName": "XONO FINANCE LTD",
+  "description": "Next-generation business banking platform for SMEs offering multi-currency IBAN accounts, corporate debit cards, crypto wallets, FX/swap, payroll, e-commerce payments, and invoicing. Also operates XONO Pro, providing white-label BaaS, WaaS, CaaS, card issuing/acquiring, and crypto processing infrastructure for financial institutions and enterprises. Visa and Mastercard Principal Member.",
+  "verified": false,
+  "status": "live",
+  "icon": "https://icons.duckduckgo.com/ip3/xono.finance.ico",
+  "websiteUrl": "https://xono.finance/",
+  "countryHQ": "CY",
+  "countries": [
+    "CY",
+    "US",
+    "PL"
+  ],
+  "webApplication": true,
+  "mobileApps": [],
+  "compliance": [],
+  "developerPortalUrl": null,
+  "apiStandards": [],
+  "apiProducts": [],
+  "apiAggregators": [],
+  "ownership": [],
+  "stateOwned": false,
+  "stockSymbol": null,
+  "twitter": "XonoFinance",
+  "linkedin": "company/xonofinance"
+}


### PR DESCRIPTION
## Summary
Adds XONO (xono.finance) as an account provider.

- **What:** Next-gen business banking for SMEs — multi-currency IBAN, corporate cards, crypto wallets, FX/swap, payroll, e-commerce pay, SoftPOS invoicing.
- **Also:** XONO Pro — white-label BaaS/WaaS/CaaS infrastructure (card issuing/acquiring, crypto processing, payment gateway) for FIs and enterprises.
- **Entity:** XONO FINANCE LTD, registered in Cyprus (reg. C470548, 2025-01-30).
- **Licenses (per their site):** MTL active in AZ + DE (US), SPI active in Poland. EMI/DLT in progress in Gibraltar + UK, PSP/CASP in progress in Bahrain.
- **Network:** Visa and Mastercard Principal Member.

Marked `verified: false` pending operator confirmation. `apiAggregators` left empty — no public open-banking aggregator linkage identified yet.

## Sources
- https://xono.finance/
- https://companieshousecyprus.com/company/C470548/
- https://x.com/XonoFinance

🤖 Generated with [Claude Code](https://claude.com/claude-code)