### PR TITLE
feat(account-providers): add Snappi

### DIFF
--- a/data/account-providers/snappi.json
+++ b/data/account-providers/snappi.json
@@ -1,0 +1,53 @@
+{
+  "id": "snappi",
+  "type": [
+    "account"
+  ],
+  "bankType": [
+    "challenger",
+    "retail"
+  ],
+  "name": "Snappi",
+  "legalName": "SNAPPI S.A.",
+  "description": "The first Greek neobank fully licensed by the European Central Bank (June 2024), offering Greek IBAN accounts, virtual and physical debit cards, IRIS payments, savings (1.0% interest), Pay Later (4 interest-free installments), and an interest-free Cash Now loan. A joint initiative between Piraeus Group and Natech. PSD2-compliant Open Banking APIs are live in production with SDKs in C#, JavaScript, Ruby, Python, and Go.",
+  "verified": false,
+  "status": "live",
+  "icon": "https://icons.duckduckgo.com/ip3/www.snappibank.com.ico",
+  "websiteUrl": "https://www.snappibank.com/en/",
+  "countryHQ": "GR",
+  "countries": [
+    "GR"
+  ],
+  "webApplication": false,
+  "mobileApps": [],
+  "compliance": [
+    {
+      "regulation": "PSD2",
+      "status": "compliant"
+    }
+  ],
+  "developerPortalUrl": "https://docs.snappibank.com/",
+  "apiStandards": [],
+  "apiProducts": [
+    {
+      "type": "accountInformation"
+    },
+    {
+      "type": "paymentInitiation"
+    }
+  ],
+  "apiAggregators": [],
+  "ownership": [
+    {
+      "name": "Piraeus Financial Holdings",
+      "type": "shareholder"
+    },
+    {
+      "name": "Natech",
+      "type": "shareholder"
+    }
+  ],
+  "stateOwned": false,
+  "stockSymbol": null,
+  "bic": "SNPIGR2AXXX"
+}


### PR DESCRIPTION
## Summary
Adds Snappi (snappibank.com), the first Greek neobank fully licensed by the European Central Bank.

- **Legal entity:** SNAPPI S.A. (BIC: `SNPIGR2AXXX`)
- **HQ:** Ioannina, Greece
- **License:** ECB universal banking licence, granted 2024-06-28 following Bank of Greece proposal
- **Ownership:** joint initiative of Piraeus Financial Holdings and Natech (technology partner)
- **Products:** Greek IBAN accounts, virtual + physical debit cards, IRIS payments, 1.0% savings, BNPL (Snappi Pay Later), interest-free Cash Now loan
- **API:** PSD2-compliant Open Banking APIs **in production** ([docs.snappibank.com](https://docs.snappibank.com/)) with SDKs for C#, JS, Ruby, Python, Go. Logged AISP + PISP products on that basis.

Marked `verified: false` pending operator confirmation.

## Sources
- https://www.snappibank.com/en/
- https://docs.snappibank.com/
- https://www.snappibank.com/en/open-banking-apis-now-available-in-production-environment/
- https://natechbanking.com/press-and-media/snappi-receives-banking-license-from-the-european-central-bank/

🤖 Generated with [Claude Code](https://claude.com/claude-code)