### PR TITLE
feat(account-providers): add River, Bushel, PenFed + Plaid links for recent Plaid bank launches

### DIFF
--- a/data/account-providers/bushel.json
+++ b/data/account-providers/bushel.json
@@ -1,0 +1,33 @@
+{
+  "id": "bushel",
+  "type": [
+    "account"
+  ],
+  "bankType": [
+    "challenger"
+  ],
+  "name": "Bushel",
+  "legalName": "Bushel, Inc.",
+  "description": "Software and payments platform for US agriculture — growers, grain buyers, ag retailers, protein producers, and food companies. Bushel Wallet offers business accounts with banking services provided by The Bancorp Bank, N.A., and connects to up to six external bank accounts via the Plaid network for settlements, ag lending, and invoice payments. HQ in Fargo, North Dakota.",
+  "verified": false,
+  "status": "live",
+  "icon": "https://icons.duckduckgo.com/ip3/bushelpowered.com.ico",
+  "websiteUrl": "https://bushelpowered.com/",
+  "countryHQ": "US",
+  "countries": [
+    "US"
+  ],
+  "webApplication": true,
+  "mobileApps": [],
+  "compliance": [],
+  "developerPortalUrl": null,
+  "apiStandards": [],
+  "apiProducts": [],
+  "apiAggregators": [
+    "plaid"
+  ],
+  "ownership": [],
+  "stateOwned": false,
+  "stockSymbol": null,
+  "thirdPartyBankingLicense": "the-bancorp-bank"
+}

--- a/data/account-providers/coinbase.json
+++ b/data/account-providers/coinbase.json
@@ -66,7 +66,8 @@
   "apiAggregators": [
     "lunchflow",
     "snaptrade",
-    "banksync"
+    "banksync",
+    "plaid"
   ],
   "collections": [],
   "sdks": [

--- a/data/account-providers/crypto-com.json
+++ b/data/account-providers/crypto-com.json
@@ -34,7 +34,8 @@
   "apiStandards": [],
   "apiStatusUrls": [],
   "apiAggregators": [
-    "salt-edge"
+    "salt-edge",
+    "plaid"
   ],
   "collections": [],
   "webApplication": true,

--- a/data/account-providers/erebor-bank.json
+++ b/data/account-providers/erebor-bank.json
@@ -23,7 +23,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/flex.json
+++ b/data/account-providers/flex.json
@@ -23,7 +23,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "plaid"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/penfed.json
+++ b/data/account-providers/penfed.json
@@ -1,0 +1,33 @@
+{
+  "id": "penfed",
+  "type": [
+    "account"
+  ],
+  "bankType": [
+    "credit-union",
+    "retail"
+  ],
+  "name": "PenFed Credit Union",
+  "legalName": "Pentagon Federal Credit Union",
+  "description": "One of the largest US credit unions, serving over 2.9 million members worldwide with $34B+ in assets. Established in 1935 as the War Department Credit Union. Headquartered in Tysons, Virginia. Open to all — no military service required for membership.",
+  "verified": false,
+  "status": "live",
+  "icon": "https://icons.duckduckgo.com/ip3/www.penfed.org.ico",
+  "websiteUrl": "https://www.penfed.org/",
+  "countryHQ": "US",
+  "countries": [
+    "US"
+  ],
+  "webApplication": true,
+  "mobileApps": [],
+  "compliance": [],
+  "developerPortalUrl": null,
+  "apiStandards": [],
+  "apiProducts": [],
+  "apiAggregators": [
+    "plaid"
+  ],
+  "ownership": [],
+  "stateOwned": false,
+  "stockSymbol": null
+}

--- a/data/account-providers/river.json
+++ b/data/account-providers/river.json
@@ -1,0 +1,34 @@
+{
+  "id": "river",
+  "type": [
+    "account",
+    "crypto",
+    "brokerage"
+  ],
+  "bankType": [
+    "challenger"
+  ],
+  "name": "River",
+  "legalName": "River Financial Inc.",
+  "description": "Bitcoin-focused financial services company offering buy/sell, custody, USD cash management, lightning network payments, and bitcoin-collateralized lending. Founded 2019 with the mission to build a Bitcoin-native bank. HQ in San Francisco with a global operations center in Columbus, Ohio.",
+  "verified": false,
+  "status": "live",
+  "icon": "https://icons.duckduckgo.com/ip3/river.com.ico",
+  "websiteUrl": "https://river.com/",
+  "countryHQ": "US",
+  "countries": [
+    "US"
+  ],
+  "webApplication": true,
+  "mobileApps": [],
+  "compliance": [],
+  "developerPortalUrl": null,
+  "apiStandards": [],
+  "apiProducts": [],
+  "apiAggregators": [
+    "plaid"
+  ],
+  "ownership": [],
+  "stateOwned": false,
+  "stockSymbol": null
+}


### PR DESCRIPTION
## Summary
Following Plaid CEO Zach Perret's announcement of recent bank launches on Plaid ("Coinbase Card, Crypto.com Card, Erebor, Rho, Flex, River, Rho, Bushel, PenFed CU"), this PR fills the gaps in the data repo.

### New providers (3)
| ID | Name | Notes |
|---|---|---|
| `river` | River | Bitcoin-focused financial services (river.com), SF + Columbus OH |
| `bushel` | Bushel | US agriculture payments platform (bushelpowered.com), Fargo ND, banking via The Bancorp Bank |
| `penfed` | PenFed Credit Union | Pentagon Federal Credit Union, Tysons VA, $34B+ assets, 2.9M+ members |

### Updated providers (4) — added `plaid` to `apiAggregators`
- `coinbase` (was: lunchflow, snaptrade, banksync)
- `crypto-com` (was: salt-edge)
- `erebor-bank` (was: empty)
- `flex` (was: empty)

### Not included
- "Coinbase Card" / "Crypto.com Card" → represented by their parent entries (`coinbase`, `crypto-com`). Separate card-product entries can be added later if desired.
- `rho-business-banking` already had `plaid`; no change needed.

All entries marked `verified: false` pending operator confirmation.

## Sources
- https://x.com/zachperret (announcement)
- https://river.com/about
- https://bushelpowered.com/
- https://www.penfed.org/

🤖 Generated with [Claude Code](https://claude.com/claude-code)