### PR TITLE
fix(fidbank-uk): rename Union Bank UK Plc to FidBank UK Limited

### DIFF
--- a/data/account-providers/fidbank-uk-limited.json
+++ b/data/account-providers/fidbank-uk-limited.json
@@ -1,17 +1,17 @@
 {
-  "id": "union-bank-uk-plc",
+  "id": "fidbank-uk-limited",
   "type": [
     "account"
   ],
   "bankType": [
     "retail"
   ],
-  "name": "UNION BANK UK PLC",
-  "legalName": "UNION BANK UK PLC",
+  "name": "FidBank UK Limited",
+  "legalName": "FidBank UK Limited",
   "verified": false,
   "status": "live",
-  "icon": "https://icons.duckduckgo.com/ip3/www.unionbankukplc.com.ico",
-  "websiteUrl": null,
+  "icon": "https://icons.duckduckgo.com/ip3/www.fidbank.co.uk.ico",
+  "websiteUrl": "https://www.fidbank.co.uk/",
   "countryHQ": "GB",
   "countries": [
     "GB"


### PR DESCRIPTION
## Summary
- Rename `data/account-providers/union-bank-uk-plc.json` → `fidbank-uk-limited.json`
- Update `id`, `name`, `legalName`, `icon`, and `websiteUrl` to reflect the new entity
- BIC `UBNIGB2LXXX` is unchanged

## Why
Fidelity Bank Nigeria acquired Union Bank UK in September 2023, and the entity was rebranded as FidBank UK Limited (Companies House #04661188). Update prompted by an external correction notice from the institution; old slug stays redirected via the app repo.

## Sources
- https://find-and-update.company-information.service.gov.uk/company/04661188
- https://en.wikipedia.org/wiki/Union_Bank_UK
- https://wise.com/gb/swift-codes/UBNIGB2LXXX

## Test plan
- [x] `npm run validate-file -- data/account-providers/fidbank-uk-limited.json`
- [ ] Companion redirect PR in app repo: `/provider/union-bank-uk-plc` → `/provider/fidbank-uk-limited`