### PR TITLE
fix(ci): fix PR-comment 403 by moving to workflow_run trigger

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,63 @@
+name: PR Comment
+
+# Runs after "Validate Data" completes. Because workflow_run executes in the
+# context of the base repository, its GITHUB_TOKEN can be granted write scope
+# even when the triggering run came from a fork PR — which is why posting the
+# comment here (rather than inside validate-data.yml) avoids the 403
+# "Resource not accessible by integration" error.
+on:
+  workflow_run:
+    workflows: ["Validate Data"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    # Only comment for PR-triggered validation runs (skip push-to-master runs).
+    if: github.event.workflow_run.event == 'pull_request'
+
+    steps:
+      - name: ⬇️ Download PR number artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🔢 Read PR number
+        id: pr
+        run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: 📝 Comment validation result on PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const conclusion = '${{ github.event.workflow_run.conclusion }}';
+            // Only report a definitive pass/fail; ignore cancelled/skipped/etc.
+            if (conclusion !== 'success' && conclusion !== 'failure') {
+              core.info(`Skipping comment for conclusion: ${conclusion}`);
+              return;
+            }
+
+            const prNumber = Number('${{ steps.pr.outputs.number }}');
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.setFailed(`Invalid PR number: ${prNumber}`);
+              return;
+            }
+
+            const body = conclusion === 'success'
+              ? '✅ All validation checks passed for changed files!'
+              : '❌ Validation failed!\n\nPlease review the errors in the workflow logs and ensure your data follows the required schema.';
+
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });

--- a/.github/workflows/validate-data.yml
+++ b/.github/workflows/validate-data.yml
@@ -160,34 +160,16 @@ jobs:
         if: success()
         run: echo "✅ All validation checks passed for changed files!"
 
-  pr-comment:
-    runs-on: ubuntu-latest
-    needs: [validate-changed-files]
-    if: always() && github.event_name == 'pull_request'
-    
-    steps:
-      - name: 📝 Add PR comment on success
-        if: needs.validate-changed-files.result == 'success'
-        uses: actions/github-script@v6
+      # Persist the PR number so the separate (write-scoped) pr-comment workflow,
+      # which runs via workflow_run, can post a comment even for fork PRs — where
+      # github.event.workflow_run.pull_requests is empty.
+      - name: 💾 Save PR number
+        if: always() && github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: ⬆️ Upload PR number artifact
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '✅ All validation checks passed for changed files!'
-            })
-      
-      - name: 📝 Add PR comment on failure
-        if: needs.validate-changed-files.result == 'failure'
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '❌ Validation failed!\n\nPlease review the errors in the workflow logs and ensure your data follows the required schema.'
-            })
+          name: pr-number
+          path: pr-number.txt


### PR DESCRIPTION
## Problem

The `pr-comment` job in `validate-data.yml` (run #153 on PR #560) failed with:

```
RequestError [HttpError]: Resource not accessible by integration
status: 403
url: https://api.github.com/repos/.../issues/560/comments
```

The response header `x-accepted-github-permissions: issues=write; pull_requests=write` shows the `GITHUB_TOKEN` lacked write scope. PRs from forks always receive a **read-only** token on `pull_request` events for security, and that cannot be elevated by a `permissions:` block — so commenting from within the same workflow can't work for fork PRs.

## Fix

Move commenting into a dedicated workflow triggered by **`workflow_run`**, GitHub's canonical pattern for this. `workflow_run` executes in the **base-repo context**, so its token *can* be granted `pull-requests: write` / `issues: write` even when the validation run originated from a fork.

- **`validate-data.yml`** — removed the `pr-comment` job; the validation job now uploads the PR number as an artifact (`workflow_run`'s `pull_requests` array is empty for fork PRs, so the number must be passed explicitly).
- **`pr-comment.yml`** (new) — fires on `workflow_run` completion of "Validate Data", reads the real `conclusion`, and posts the pass/fail comment.
- Bumped `upload/download-artifact` to v4 (v3 retired) and `github-script` to v7.

## Note

`workflow_run` triggers are only honored from the **default branch**, so this activates only once merged to `master` — it won't be exercised on this PR itself. That's inherent to the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)