### PR TITLE
fix(ci): grant actions:read to pr-comment workflow

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   pull-requests: write
   issues: write
+  # Required by download-artifact@v4 to fetch the pr-number artifact from the
+  # separate "Validate Data" run. An explicit permissions block defaults all
+  # unlisted scopes to none, so this must be declared.
+  actions: read
 
 jobs:
   comment:


### PR DESCRIPTION
## Follow-up to #561

PR #561 moved PR commenting into a `workflow_run`-triggered workflow. That workflow downloads the `pr-number` artifact from the separate "Validate Data" run via `download-artifact@v4` with an explicit `run-id`.

**Bug:** the workflow declares an explicit `permissions:` block, which sets *all unlisted scopes to `none`*. Fetching an artifact from a different run requires `actions: read`, so the download step would have failed with a 403 before the comment could be posted.

**Fix:** add `actions: read` to the permissions block.

```yaml
permissions:
  pull-requests: write
  issues: write
  actions: read   # ← added
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)