### PR TITLE
fix(jpmel): add missing comma in Chase account features array

### DIFF
--- a/data/account-providers/jpmel.json
+++ b/data/account-providers/jpmel.json
@@ -425,7 +425,7 @@
         "real-time-notifications",
         "card-freeze-controls",
         "app-based-support",
-        "fsCS-protected-eligible-deposits"
+        "fsCS-protected-eligible-deposits",
         "credit-cards"
       ],
       "limitations": [


### PR DESCRIPTION
## What

Fixes invalid JSON in `data/account-providers/jpmel.json`. The Chase current-account `features` array was missing a comma after `"fsCS-protected-eligible-deposits"`, introduced in #560.

## Why

The app's build step (`scripts/generateAggregatorBankIndex.js`) clones this repo's `master` and parses every account-provider file. The malformed JSON caused that step to throw, failing **Vercel/CI builds on unrelated PRs** in the app repo (e.g. [open-banking-tracker-app#172](https://github.com/not-a-bank/open-banking-tracker-app/pull/172)):

```
❌ Error generating aggregator bank index: Failed to parse 1 account provider file(s):
  - jpmel.json: Expected ',' or ']' after array element in JSON at position 16142
```

## Fix

Added the missing comma. Verified the whole file now parses and the app's `generateAggregatorBankIndex.js` completes successfully (57236 providers processed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)