### PR TITLE
Add Boufin as API aggregator (Chile)

### DIFF
--- a/data/account-providers/banco-bice.json
+++ b/data/account-providers/banco-bice.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "boufin",
     "floid-io"
   ],
   "ownership": [],

--- a/data/account-providers/banco-consorcio.json
+++ b/data/account-providers/banco-consorcio.json
@@ -22,7 +22,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "boufin"
+  ],
   "ownership": [],
   "stateOwned": false,
   "stockSymbol": null,

--- a/data/account-providers/banco-de-chile.json
+++ b/data/account-providers/banco-de-chile.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "boufin",
     "floid-io"
   ],
   "ownership": [],

--- a/data/account-providers/banco-de-credito-e-inversiones.json
+++ b/data/account-providers/banco-de-credito-e-inversiones.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "boufin",
     "floid-io"
   ],
   "ownership": [],

--- a/data/account-providers/banco-falabella.json
+++ b/data/account-providers/banco-falabella.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "boufin",
     "floid-io"
   ],
   "ownership": [],

--- a/data/account-providers/banco-itau-chile.json
+++ b/data/account-providers/banco-itau-chile.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "boufin",
     "floid-io"
   ],
   "ownership": [],

--- a/data/account-providers/banco-santander-chile.json
+++ b/data/account-providers/banco-santander-chile.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "boufin",
     "floid-io"
   ],
   "ownership": [],

--- a/data/account-providers/bancoestado.json
+++ b/data/account-providers/bancoestado.json
@@ -27,7 +27,9 @@
   "developerPortalUrl": null,
   "apiStandards": [],
   "apiProducts": [],
-  "apiAggregators": [],
+  "apiAggregators": [
+    "boufin"
+  ],
   "webApplication": true,
   "mobileApps": [
     {

--- a/data/account-providers/scotiabank-chile.json
+++ b/data/account-providers/scotiabank-chile.json
@@ -23,6 +23,7 @@
   "apiStandards": [],
   "apiProducts": [],
   "apiAggregators": [
+    "boufin",
     "floid-io"
   ],
   "ownership": [],

--- a/data/api-aggregators/boufin.json
+++ b/data/api-aggregators/boufin.json
@@ -1,0 +1,18 @@
+{
+  "id": "boufin",
+  "label": "Boufin",
+  "website": "https://boufin.com/",
+  "iconUrl": "https://boufin.com/favicon.svg",
+  "developerPortalUrl": "https://doc.boufin.com/api/",
+  "twitter": null,
+  "countryHQ": "CL",
+  "verified": false,
+  "description": "Open Finance API for banks and fintechs in Chile. Banking, tax (SII) and pension (AFP) data with user consent.",
+  "marketFocus": "Chile and Latin America",
+  "bankCount": 9,
+  "marketCoverage": {
+    "live": [
+      "CL"
+    ]
+  }
+}

--- a/schema.json
+++ b/schema.json
@@ -404,6 +404,7 @@
               "banksync",
               "banqup",
               "belvo",
+              "boufin",
               "bridgeapi-io",
               "bud",
               "budget-insight",


### PR DESCRIPTION
## Summary

Adds **Boufin** (https://boufin.com), an Open Finance API aggregator headquartered in Chile, providing banking, tax (SII) and pension (AFP) data with user consent. Boufin operates under Chile's Fintech Law 21.521 / CMF framework.

## Changes

- **New aggregator file** `data/api-aggregators/boufin.json` with website, developer portal, market focus and coverage (CL).
- **Register `boufin`** in the `apiAggregators` enum in `schema.json` (alphabetical order).
- **Tag the 9 Chilean banks Boufin connects to** in their account-provider files:
  Banco de Chile, Banco Santander Chile, BCI, Scotiabank Chile, Banco Itaú Chile, BancoEstado, Banco Falabella, Banco BICE and Banco Consorcio.

## Validation

- `npm run validate-aggregators` → `boufin.json` passes the schema.
- `npm run validate-providers` → all provider data valid.

## Notes

- `iconUrl` currently points to Boufin's hosted favicon; happy to provide a logo for re-hosting on your Cloudinary if preferred.