### PR TITLE
Add Qonto MCP server to qonto-eu provider

### DIFF
--- a/data/account-providers/qonto-eu.json
+++ b/data/account-providers/qonto-eu.json
@@ -15,6 +15,28 @@
   "status": "live",
   "icon": "https://res.cloudinary.com/apideck/image/upload/v1571995818/catalog/qonto-eu/icon128x128.jpg",
   "websiteUrl": "https://qonto.eu",
+  "mcpServer": {
+    "type": "hosted",
+    "serverUrl": "https://mcp.qonto.com/mcp",
+    "authType": "oauth",
+    "documentationUrl": "https://docs.qonto.com/mcp/overview",
+    "programStatus": "live",
+    "accessLevel": "read-write",
+    "launchDate": null,
+    "capabilities": [
+      "banking-data",
+      "card-management",
+      "invoicing",
+      "payment-requests"
+    ],
+    "supportedModels": [
+      "Claude",
+      "ChatGPT",
+      "Mistral",
+      "Other LLMs"
+    ],
+    "partnerName": null
+  },
   "ownership": [],
   "stateOwned": false,
   "countryHQ": "FR",


### PR DESCRIPTION
## What

Adds the `mcpServer` block to `data/account-providers/qonto-eu.json` — the **source of truth** for the generated `constants/providerIndex/mcpProviders.json` in the app repo (`generateProviderIndex.mjs` reads `provider.mcpServer`).

Qonto's hosted MCP server:
- **Server:** `https://mcp.qonto.com/mcp` · **Auth:** OAuth · **Docs:** https://docs.qonto.com/mcp/overview
- Built on the Qonto Business API; exposes read + a vetted set of write tools: read books (transactions, statements, invoices, quotes, clients, cards, requests), manage cards, bill clients, triage requests.
- `programStatus: live`, `accessLevel: read-write`.

After this merges, regenerating the provider index will surface Qonto on `/banks-with-mcp-servers` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)